### PR TITLE
Fixing repeated sets being returned by tournament_show_sets and event_show_sets functions.

### DIFF
--- a/pysmashgg/e_queries.py
+++ b/pysmashgg/e_queries.py
@@ -25,7 +25,7 @@ SHOW_SETS_QUERY = """query EventSets($eventId: ID!, $page: Int!) {
       name
     }
     name
-    sets(page: $page, perPage: 18, sortType: STANDARD) {
+    sets(page: $page, perPage: 18, sortType: RECENT) {
       nodes {
         fullRoundText
         games {

--- a/pysmashgg/t_queries.py
+++ b/pysmashgg/t_queries.py
@@ -98,7 +98,7 @@ SHOW_SETS_QUERY = """query EventSets($eventId: ID!, $page: Int!) {
       name
     }
     name
-    sets(page: $page, perPage: 18, sortType: STANDARD) {
+    sets(page: $page, perPage: 18, sortType: RECENT) {
       nodes {
         fullRoundText
         games {


### PR DESCRIPTION
The old STANDARD sorting method in the query called by the get_sets functions for tournaments and events returned repeated sets in subsequent function calls while iterating the pagenum value in the function call. I tested the other available sorting methods, and several of them had the same problematic behavior. The new method, RECENT, is the only sorting method in my testing that does not return repeated sets in subsequent function calls.

If any issues with this new sorting method arises, please reach out to me, gaussianssbm! I'm happy to work on this more if the issue pops back up.